### PR TITLE
deb packaging

### DIFF
--- a/.github/workflows/publish_deb.yaml
+++ b/.github/workflows/publish_deb.yaml
@@ -1,0 +1,27 @@
+name: Publish deb
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Build deb package
+        if: success()
+        run: |
+          npm ci
+          npm run build
+          npx node-deb -- dist/
+      - name: Upload deb package
+        if: success()
+        uses: alexellis/upload-assets@0.3.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["etherproxy_*deb"]'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 dist
+*.deb

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "start": "ts-node src/index.ts",
         "prepare": "npm run build",
-        "build": "tsc"
+        "build": "tsc && chmod +x dist/index.js"
     },
     "keywords": [],
     "author": "@Cafe137",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "etherproxy",
     "version": "1.3.0",
-    "description": "",
+    "description": "JSON-RPC reverse proxy tool designed for caching requests",
     "main": "dist/index.js",
     "bin": {
         "etherproxy": "./dist/index.js"
@@ -12,7 +12,7 @@
         "build": "tsc"
     },
     "keywords": [],
-    "author": "",
+    "author": "@Cafe137",
     "license": "MIT",
     "dependencies": {
         "cafe-utility": "^10.8.1",
@@ -22,5 +22,17 @@
         "@types/node": "^18.15.11",
         "@types/node-fetch": "^2.6.3",
         "typescript": "^5.0.3"
+    },
+    "node_deb": {
+      "entrypoints": {
+        "daemon": "dist/index.js"
+      },
+      "init": "systemd",
+      "install_strategy": "copy",
+      "package_name": "etherproxy",
+      "templates": {
+        "default_variables": "packaging/default/etherproxy",
+        "systemd_service": "packaging/systemd/etherproxy.service"
+      }
     }
 }

--- a/packaging/default/etherproxy
+++ b/packaging/default/etherproxy
@@ -1,0 +1,5 @@
+# Configuration for etherproxy daemon
+
+#ETHERPROXY_TARGET=http://localhost:8545
+#ETHERPROXY_PORT=9000
+#ETHERPROXY_EXPIRY=2000

--- a/packaging/systemd/etherproxy.service
+++ b/packaging/systemd/etherproxy.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=JSON-RPC reverse proxy tool designed for caching requests
+Requires=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/etherproxy
+WorkingDirectory=/usr/share/etherproxy/app
+ExecStart=/usr/share/etherproxy/app/dist/index.js
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+User=etherproxy
+PermissionsStartOnly=true
+SyslogIdentifier=etherproxy
+
+[Install]
+WantedBy=multi-user.target

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,9 @@ import { fetchWithTimeout, respondWithFetchPromise } from './utility'
 main()
 
 function main() {
-    const port = Arrays.requireNumberArgument(process.argv, 'port')
-    const target = Arrays.requireStringArgument(process.argv, 'target')
-    const expiry = Arrays.requireNumberArgument(process.argv, 'expiry')
+    const port: number = parseInt(Arrays.getArgument(process.argv, 'port') as string) || parseInt((process.env.ETHERPROXY_PORT as string)) || 9000
+    const target: string = Arrays.getArgument(process.argv, 'target') as string || process.env.ETHERPROXY_TARGET as string || "http://localhost:8545"
+    const expiry: number = parseInt(Arrays.getArgument(process.argv, 'expiry') as string) || parseInt((process.env.ETHERPROXY_EXPIRY as string)) || 2000
 
     const fastIndex = Objects.createFastIndex()
     const server = createServer(async (request: IncomingMessage, response: ServerResponse) => {


### PR DESCRIPTION
This PR enables etherproxy to be packaged as deb and started as systemd service.
Publish deb workflow will be executed only after release happened and release has to exists before this workflow because deb file can to be only uploaded to an existing release.
Enabling ENV variables inside `index.ts` was needed because systemd ExecStart doesn't support ENV variables so process has to be started only with `ExecStart=/usr/share/etherproxy/app/dist/index.js`
There are sane defaults if no option (argument, env vars) is specified.